### PR TITLE
Add unit and integration tests for Accounts service with Maven test s…

### DIFF
--- a/accounts/pom.xml
+++ b/accounts/pom.xml
@@ -95,6 +95,30 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>5.8.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.10.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>1.19.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>com.akash</groupId>
 			<artifactId>common</artifactId>
 			<version>0.0.1</version>
@@ -126,6 +150,37 @@
 						</exclude>
 					</excludes>
 				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.0.0</version>
+				<configuration>
+					<includes>
+						<include>**/unit/**/*Test.java</include>
+					</includes>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>3.0.0</version>
+				<executions>
+					<execution>
+						<id>integration-tests</id>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+						<configuration>
+							<includes>
+								<include>**/integration/**/*Test.java</include>
+							</includes>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/accounts/src/test/java/com/akash/accounts/integration/service/AccountsControllerTest.java
+++ b/accounts/src/test/java/com/akash/accounts/integration/service/AccountsControllerTest.java
@@ -1,0 +1,73 @@
+package com.akash.accounts.integration.service;
+
+import com.akash.accounts.dto.AccountsDto;
+import com.akash.accounts.dto.CustomerDto;
+import com.akash.accounts.dto.ResponseDto;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.*;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Author: akash
+ * Date: 28/7/25
+ */
+@ActiveProfiles("it")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class AccountsControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    private String getBaseUrl(String path) {
+        return "http://localhost:" + port + "/api" + path;
+    }
+
+    @Test
+    void testCreateAndFetchAccount() {
+        // Prepare customer data
+        CustomerDto customerDto = new CustomerDto();
+        customerDto.setName("Akash Bhuiyan");
+        customerDto.setEmail("akash@example.com");
+        customerDto.setMobileNumber("01712345678");
+
+        // Send POST request to /create
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<CustomerDto> request = new HttpEntity<>(customerDto, headers);
+
+        ResponseEntity<ResponseDto> createResponse = restTemplate.postForEntity(
+                getBaseUrl("/create"), request, ResponseDto.class
+        );
+
+        assertEquals(HttpStatus.CREATED, createResponse.getStatusCode());
+        assertNotNull(createResponse.getBody());
+        assertEquals("201", createResponse.getBody().getStatusCode());
+
+        // Send GET request to /fetch
+        ResponseEntity<CustomerDto> fetchResponse = restTemplate.getForEntity(
+                getBaseUrl("/fetch?mobileNumber=01712345678"), CustomerDto.class
+        );
+
+        assertEquals(HttpStatus.OK, fetchResponse.getStatusCode());
+        assertNotNull(fetchResponse.getBody());
+        assertEquals("Akash Bhuiyan", fetchResponse.getBody().getName());
+
+        AccountsDto accountsDto = fetchResponse.getBody().getAccountsDto();
+        assertNotNull(accountsDto);
+        assertEquals("Savings", accountsDto.getAccountType());
+    }
+}
+

--- a/accounts/src/test/java/com/akash/accounts/integration/service/AccountsServiceTest.java
+++ b/accounts/src/test/java/com/akash/accounts/integration/service/AccountsServiceTest.java
@@ -1,0 +1,52 @@
+package com.akash.accounts.integration.service;
+
+import com.akash.accounts.dto.CustomerDto;
+import com.akash.accounts.service.IAccountsService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Author: akash
+ * Date: 28/7/25
+ */
+@ActiveProfiles("it")
+@Testcontainers
+@SpringBootTest
+public class AccountsServiceTest {
+
+    @Autowired
+    private IAccountsService accountsService;
+
+    @Test
+    void testCreateAndFetch() {
+        // Step 1: Create CustomerDto with test data
+        CustomerDto customerDto = new CustomerDto();
+        customerDto.setName("Akash Bhuiyan");
+        customerDto.setEmail("akash@example.com");
+        customerDto.setMobileNumber("5551234567");
+
+        // Step 2: Create account
+        accountsService.createAccount(customerDto);
+
+        // Step 3: Fetch account by mobile number
+        CustomerDto fetchedDto = accountsService.fetchAccount("5551234567");
+
+        // Step 4: Assertions
+        assertNotNull(fetchedDto, "Fetched customer should not be null");
+        assertEquals("Akash Bhuiyan", fetchedDto.getName());
+        assertEquals("akash@example.com", fetchedDto.getEmail());
+        assertEquals("5551234567", fetchedDto.getMobileNumber());
+
+        assertNotNull(fetchedDto.getAccountsDto(), "Account details should not be null");
+        assertEquals("Savings", fetchedDto.getAccountsDto().getAccountType()); // Assuming default type is 'Savings'
+        assertEquals("10/3 Gulshan 1, Dhaka", fetchedDto.getAccountsDto().getBranchAddress()); // Based on AccountsConstants.ADDRESS
+    }
+
+}
+

--- a/accounts/src/test/java/com/akash/accounts/unit/service/AccountsServiceImplTest.java
+++ b/accounts/src/test/java/com/akash/accounts/unit/service/AccountsServiceImplTest.java
@@ -1,0 +1,149 @@
+package com.akash.accounts.unit.service;
+
+import com.akash.accounts.constants.AccountsConstants;
+import com.akash.accounts.dto.AccountsDto;
+import com.akash.accounts.dto.CustomerDto;
+import com.akash.accounts.entity.Accounts;
+import com.akash.accounts.entity.Customer;
+import com.akash.accounts.exception.CustomerAlreadyExistsException;
+import com.akash.accounts.exception.ResourceNotFoundException;
+import com.akash.accounts.repository.AccountsRepository;
+import com.akash.accounts.repository.CustomerRepository;
+import com.akash.accounts.service.impl.AccountsServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Author: akash
+ * Date: 28/7/25
+ */
+class AccountsServiceImplTest {
+
+    @Mock
+    private AccountsRepository accountsRepository;
+
+    @Mock
+    private CustomerRepository customerRepository;
+
+    @InjectMocks
+    private AccountsServiceImpl accountsService;
+
+    private CustomerDto customerDto;
+    private Customer customer;
+    private Accounts account;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        customerDto = new CustomerDto();
+        customerDto.setMobileNumber("1234567890");
+        customerDto.setName("Akash Bhuiyan");
+
+        customer = new Customer();
+        customer.setCustomerId(1L);
+        customer.setMobileNumber("1234567890");
+        customer.setName("Akash Bhuiyan");
+
+        account = new Accounts();
+        account.setAccountNumber(1234567890L);
+        account.setCustomerId(1L);
+        account.setAccountType(AccountsConstants.SAVINGS);
+        account.setBranchAddress(AccountsConstants.ADDRESS);
+    }
+
+    @Test
+    void testCreateAccount_success() {
+        when(customerRepository.findByMobileNumber("1234567890")).thenReturn(Optional.empty());
+        when(customerRepository.save(any(Customer.class))).thenReturn(customer);
+        when(accountsRepository.save(any(Accounts.class))).thenReturn(account);
+
+        assertDoesNotThrow(() -> accountsService.createAccount(customerDto));
+
+        verify(customerRepository, times(1)).save(any(Customer.class));
+        verify(accountsRepository, times(1)).save(any(Accounts.class));
+    }
+
+    @Test
+    void testCreateAccount_customerAlreadyExists() {
+        when(customerRepository.findByMobileNumber("1234567890")).thenReturn(Optional.of(customer));
+
+        assertThrows(CustomerAlreadyExistsException.class, () -> accountsService.createAccount(customerDto));
+
+        verify(customerRepository, never()).save(any(Customer.class));
+        verify(accountsRepository, never()).save(any(Accounts.class));
+    }
+
+    @Test
+    void testFetchAccount_success() {
+        when(customerRepository.findByMobileNumber("1234567890")).thenReturn(Optional.of(customer));
+        when(accountsRepository.findByCustomerId(1L)).thenReturn(Optional.of(account));
+
+        CustomerDto result = accountsService.fetchAccount("1234567890");
+
+        assertNotNull(result);
+        assertEquals("1234567890", result.getMobileNumber());
+        assertNotNull(result.getAccountsDto());
+        assertEquals(account.getAccountNumber(), result.getAccountsDto().getAccountNumber());
+    }
+
+    @Test
+    void testFetchAccount_customerNotFound() {
+        when(customerRepository.findByMobileNumber("1234567890")).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> accountsService.fetchAccount("1234567890"));
+    }
+
+    @Test
+    void testUpdateAccount_success() {
+        AccountsDto accountsDto = new AccountsDto();
+        accountsDto.setAccountNumber(1234567890L);
+        customerDto.setAccountsDto(accountsDto);
+
+        when(accountsRepository.findById(1234567890L)).thenReturn(Optional.of(account));
+        when(customerRepository.findById(1L)).thenReturn(Optional.of(customer));
+        when(accountsRepository.save(any(Accounts.class))).thenReturn(account);
+        when(customerRepository.save(any(Customer.class))).thenReturn(customer);
+
+        boolean result = accountsService.updateAccount(customerDto);
+
+        assertTrue(result);
+        verify(accountsRepository).save(any(Accounts.class));
+        verify(customerRepository).save(any(Customer.class));
+    }
+
+    @Test
+    void testUpdateAccount_accountNotFound() {
+        AccountsDto accountsDto = new AccountsDto();
+        accountsDto.setAccountNumber(9999999999L);
+        customerDto.setAccountsDto(accountsDto);
+
+        when(accountsRepository.findById(9999999999L)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> accountsService.updateAccount(customerDto));
+    }
+
+    @Test
+    void testDeleteAccount_success() {
+        when(customerRepository.findByMobileNumber("1234567890")).thenReturn(Optional.of(customer));
+
+        boolean result = accountsService.deleteAccount("1234567890");
+
+        assertTrue(result);
+        verify(accountsRepository).deleteByCustomerId(1L);
+        verify(customerRepository).deleteById(1L);
+    }
+
+    @Test
+    void testDeleteAccount_customerNotFound() {
+        when(customerRepository.findByMobileNumber("1234567890")).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> accountsService.deleteAccount("1234567890"));
+    }
+}

--- a/accounts/src/test/resources/application-it.yml
+++ b/accounts/src/test/resources/application-it.yml
@@ -1,0 +1,83 @@
+server:
+  port: 0  # Let Spring Boot choose a random port to avoid conflicts
+
+spring:
+  application:
+    name: accounts-test
+
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop  # Clean schema for each test run
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: true
+
+  sql:
+    init:
+      mode: always
+
+  main:
+    allow-bean-definition-overriding: true
+
+# Disable cloud dependencies for test
+eureka:
+  client:
+    enabled: false
+  instance:
+    register-with-eureka: false
+
+spring.cloud.config.enabled: false
+spring.cloud.openfeign.circuitbreaker.enabled: false
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  health:
+    probes:
+      enabled: false
+  endpoint:
+    shutdown:
+      enabled: false
+
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        failureRateThreshold: 100  # open fast in case you're testing failure
+  retry:
+    configs:
+      default:
+        maxAttempts: 1  # no retry during test
+  ratelimiter:
+    configs:
+      default:
+        limitForPeriod: 1000  # effectively no limit during tests
+
+logging:
+  level:
+    root: WARN
+    com.akash.accounts: DEBUG
+
+build:
+  version: "3.0"
+
+accounts:
+  message: "Welcome to Bank accounts related local APIs "
+  contactDetails:
+    name: "Akash - Developer"
+    email: "akash@example.com"
+  onCallSupport:
+    - +8801XXXXXXXXX
+    - +8801XXXXXXXX3


### PR DESCRIPTION
…etup

- Added unit tests for AccountsServiceImpl using Mockito to cover create, fetch, update, and delete account scenarios, including exception handling.
- Created integration tests for AccountsController and AccountsService with Spring Boot TestRestTemplate and Testcontainers, validating REST endpoints and service behavior.
- Updated Maven dependencies with junit-jupiter, mockito-core, testcontainers, and h2 for test scope.
- Configured maven-surefire-plugin for unit tests and maven-failsafe-plugin for integration tests, separating test execution.
- Applied @ActiveProfiles("it") for integration test environment isolation.
- application-it.yml test profile added